### PR TITLE
[Nginx]: Fix ssl cert imports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     volumes:
       - ./nginx:/etc/nginx:cached
       - ./nginx/nginx.local.conf:/etc/nginx/nginx.conf
+      - ./nginx/local-ssl:/etc/nginx/ssl:cached
   ############################### REDIS ###############################
   # redis
   redis:


### PR DESCRIPTION
Error:

> nginx-1     | 2025/06/18 15:45:14 [emerg] 1#1: cannot load certificate "/etc/nginx/ssl/localhost.crt": BIO_new_file() failed (SSL: error:80000002:system library::No such file or directory:calling fopen(/etc/nginx/ssl/localhost.crt, r) error:10000080:BIO routines::no such file)
nginx-1     | nginx: [emerg] cannot load certificate "/etc/nginx/ssl/localhost.crt": BIO_new_file() failed (SSL: error:80000002:system library::No such file or directory:calling fopen(/etc/nginx/ssl/localhost.crt, r) error:10000080:BIO routines::no such file)
