### PR TITLE
Remove CMS from local development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Huntd public
 
-Anonymous job search in IT(public version).
+Anonymous job search in IT (public version).
 
 ## Setup environment
 
@@ -8,26 +8,26 @@ Anonymous job search in IT(public version).
 
 2. Clone repository:
     ```bash
-   git clone git@github.com:mate-academy/huntd-public.git
+   git clone git@github.com:mate-academy/huntd-test.git
    ```
 3. Setup local `.env` file
   - Run `make init` to copy `.env.sample` -> `.env`
   - Insert on the 4th line the NPM_TOKEN you were given
 4. Install dependencies (node modules) for primary services locally(make sure correct node version is used, check .nvmrc file):
     ```bash
-    npm install # in root, ./frontend, ./api, ./cms
+    npm install # in root, ./frontend, ./api
     ```
 
 ## Run project
 
-To run the project run following command in the root directory(INSERT NPM TOKEN INTO MAKEFILE BEFORE RUNNING IT):
+To run the project run following command in the root directory (INSERT NPM TOKEN INTO MAKEFILE BEFORE RUNNING IT):
 ```bash
   make up
 ```
 
 After project has started up it should be accessible at `http://localhost:3000`
 
-Project contains following services combined in `docker-compose`:
+Project contains following services combined in `docker compose`:
 - **API:**
     - Codebase: './api'
     - Graphql endpoint: `http://localhost:4000/graphql`
@@ -46,13 +46,11 @@ Project contains following services combined in `docker-compose`:
 
     [NextJS](https://nextjs.org) is used for serving UI on Huntd. Complete official [guide](https://nextjs.org/learn) and read the [docs](https://nextjs.org/docs) to get familiar with NextJS features.
 
-- **CMS:**
+- **CMS (Production only - not required for test assignment):**
     - Codebase: './cms'
     - Homepage: `https://local.hutnd.tech/admin`
 
-  [Strapi](https://strapi.io) is used as a CMS on Huntd. Read official [docs](https://strapi.io/documentation) to get familiar with strapi features.
-
-  On Huntd it's possible to use Typescript in Strapi while developing custom plugins even despite TS is not supported officially.
+  [Strapi](https://strapi.io) is used as a CMS on Huntd in production. This service is not included in the local development setup for the test assignment.
 
 - **NGINX:**
     - Codebase: './nginx'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     depends_on:
       - api
       - frontend
-      - cms
       - db
     volumes:
       - ./nginx:/etc/nginx:cached
@@ -26,32 +25,6 @@ services:
     image: redis:5.0
     ports:
       - '6379:6379'
-
-  ################################# CMS ################################
-  # strapi cms
-  cms:
-    restart: always
-    command: ["./wait-for-it.sh", "api:4000/healthz", "npm", "run", "dev", "-- --watch-admin"]
-    build:
-      context: ./cms
-      args:
-        - APP_ENV=${APP_ENV}
-        - NPM_TOKEN=${NPM_TOKEN}
-    image: huntd/huntd-cms:${TAG}
-    ports:
-      - 1337:1337
-      - 8000:8000
-    depends_on:
-      - api
-    env_file:
-      - .env
-    volumes:
-      - ./cms:/usr/src/cms:cached
-      # monkey patch to disable host check in webpack dev server (use local.huntd.tech for admin development)
-      - ./cms/overwrites/strapi-admin/index.js:/usr/src/cms/node_modules/strapi-admin/index.js:cached
-      - /usr/src/cms/node_modules
-      - /usr/src/cms/.cache
-      - /usr/src/cms/build
 
   # ################################ API ################################
   # sequelize + graphql wrapper over postgres database

--- a/nginx/nginx.local.conf
+++ b/nginx/nginx.local.conf
@@ -3,15 +3,6 @@ events {
 }
 
 http {
-
-  upstream cms {
-    server cms:8000;
-  }
-
-  upstream cms-api {
-      server cms:1337;
-    }
-
   upstream frontend {
     server frontend:3000;
   }
@@ -36,43 +27,8 @@ http {
     listen 443 http2 ssl;
     listen [::]:443 http2 ssl;
 
-
     ssl_certificate /etc/nginx/ssl/localhost.crt;
     ssl_certificate_key /etc/nginx/ssl/localhost.key;
-
-    location ^~ /sockjs-node {
-      proxy_pass http://cms/sockjs-node;
-      proxy_redirect off;
-      proxy_http_version 1.1;
-      proxy_set_header X-Forwarded-Host $host;
-      proxy_set_header X-Forwarded-Server $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header Host $http_host;
-
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "Upgrade";
-      proxy_pass_request_headers on;
-    }
-
-    location ^~ /__webpack_dev_server__ {
-      proxy_pass http://cms/__webpack_dev_server__;
-      proxy_redirect off;
-      proxy_http_version 1.1;
-      proxy_set_header X-Forwarded-Host $host;
-      proxy_set_header X-Forwarded-Server $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header Host $http_host;
-
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "Upgrade";
-      proxy_pass_request_headers on;
-    }
-
-
   }
 
   server {
@@ -83,11 +39,9 @@ http {
 
     include /etc/nginx/snippets/ssl.conf;
 
-    include /etc/nginx/snippets/cms.locations.local.conf;
     include /etc/nginx/snippets/api.locations.conf;
     include /etc/nginx/snippets/frontend.locations.conf;
 
     client_max_body_size 8M;
-
   }
 }


### PR DESCRIPTION
## Summary
Remove CMS service from `docker-compose.yml` to simplify local development setup for test candidates.